### PR TITLE
Change table engine to InnoDB

### DIFF
--- a/expiry/assets/expiry.sql
+++ b/expiry/assets/expiry.sql
@@ -6,4 +6,4 @@ CREATE TABLE IF NOT EXISTS `expiry` (
   `shelflife` varchar(20),
   `postexpire` varchar(200),
   PRIMARY KEY  (`keyword`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/expiry/plugin.php
+++ b/expiry/plugin.php
@@ -1444,7 +1444,7 @@ function expiry_activated() {
 		$table_expiry .= "shelflife varchar(20), ";
 		$table_expiry .= "postexpire varchar(200), ";
 		$table_expiry .= "PRIMARY KEY (keyword) ";
-		$table_expiry .= ") ENGINE=MyISAM DEFAULT CHARSET=latin1;";
+		$table_expiry .= ") ENGINE=InnoDB DEFAULT CHARSET=latin1;";
 
 		if (version_compare(YOURLS_VERSION, '1.7.3') >= 0) {
 			$tables = $ydb->fetchAffected($table_expiry);


### PR DESCRIPTION
MyISAM on MySQL 8 has some performance issue on request: 
SQL: SELECT * FROM expiry WHERE BINARY `keyword` = '084BVoNTJR' (0.46792 s)

On MySQL 5.7 time is ~0.1 s 
On MySQL 8 and InnoDB ~0.1 s 