### PR TITLE
fix mysql high cpu utilization

### DIFF
--- a/expiry/plugin.php
+++ b/expiry/plugin.php
@@ -568,7 +568,7 @@ function show_expiry_tablerow($row, $keyword, $url, $title, $ip, $clicks, $times
 		// If the keyword is set to expire, make the URL show in green;
 		$table = YOURLS_DB_PREFIX . 'expiry';
 
-		$sql = "SELECT * FROM $table WHERE BINARY `keyword` = :keyword";
+		$sql = "SELECT * FROM $table WHERE `keyword` = :keyword";
 		$binds = array('keyword' => $keyword);
 		$expiry = $ydb->fetchOne($sql, $binds);
 	
@@ -1282,7 +1282,7 @@ function expiry_activated() {
 	// Create the expiry table
 	$table = YOURLS_DB_PREFIX . 'expiry';
 	$table_expiry  = "CREATE TABLE IF NOT EXISTS `".$table."` (";
-	$table_expiry .= "keyword varchar(200) NOT NULL, ";
+	$table_expiry .= "keyword binary(100) NOT NULL, ";
 	$table_expiry .= "type varchar(5) NOT NULL, ";
 	$table_expiry .= "click varchar(5), ";
 	$table_expiry .= "timestamp varchar(20), ";


### PR DESCRIPTION
Changing column yourls_expiry.keyword type to BINARY and excluding this from SELECT allows to lower CPU utilization to 0.1m from 3-5m in such requests with 10rps:
/yourls-api.php?signature=xxx&action=shorturl&expiry=clock&url=https://url/test?agreement%3D123%26clientId%3Dqqq%26timestamp%3D2020123001%26secret%3Drwq%26grantType%3Dreferal%26city_id%3D1%26ctrk%3D14695631803%26yourls_nodecode%3D1&age=6&title=qqqq1&format=json&keyword=1tAfwFAFW-PYstha7ka1Be-I%3D
before:
![image](https://user-images.githubusercontent.com/18414214/103399637-be363080-4b63-11eb-92bd-f16f64bb5321.png)
after:
![image](https://user-images.githubusercontent.com/18414214/103399655-db6aff00-4b63-11eb-806c-388d1d6c1235.png)
